### PR TITLE
알람 기능 분리, 주요 코드 리팩토링 

### DIFF
--- a/src/main/java/com/windmealchat/chat/controller/StompChatController.java
+++ b/src/main/java/com/windmealchat/chat/controller/StompChatController.java
@@ -2,9 +2,6 @@ package com.windmealchat.chat.controller;
 
 import static com.windmealchat.global.constants.RabbitConstants.CHAT_QUEUE_NAME;
 
-import com.windmealchat.alarm.dto.FcmNotificationRequest;
-import com.windmealchat.alarm.service.FcmNotificationService;
-import com.windmealchat.chat.dto.request.ChatInitialRequest;
 import com.windmealchat.chat.dto.request.MessageDTO;
 import com.windmealchat.chat.dto.response.ChatMessageResponse.ChatMessageSpecResponse;
 import com.windmealchat.chat.service.StompChatService;
@@ -24,40 +21,20 @@ import org.springframework.stereotype.Controller;
 @RequiredArgsConstructor
 public class StompChatController {
 
-  private final FcmNotificationService fcmNotificationService;
   private final StompChatService stompChatService;
   private final TokenService tokenService;
-
-  @MessageMapping(value = "chat.enter.{chatRoomId}")
-  public void enter(@DestinationVariable String chatRoomId, ChatInitialRequest chatInitialRequest,
-      StompHeaderAccessor accessor) {
-    Optional<MemberInfoDTO> memberInfoOptional = tokenService.resolveJwtToken(accessor);
-    if (memberInfoOptional.isPresent()) {
-      stompChatService.enter(chatRoomId, chatInitialRequest, memberInfoOptional.get());
-    }
-  }
 
   @MessageMapping(value = "chat.message.{chatRoomId}")
   public void sendMessage(@DestinationVariable String chatRoomId, MessageDTO messageDTO,
       StompHeaderAccessor accessor) {
     Optional<MemberInfoDTO> memberInfoOptional = tokenService.resolveJwtToken(accessor);
-    String alarmToken = tokenService.resolveAlarmToken(accessor);
-    if (memberInfoOptional.isPresent()) {
-      sendNotification(messageDTO, alarmToken);
-      stompChatService.sendMessage(chatRoomId, messageDTO, memberInfoOptional.get());
-    }
+    memberInfoOptional.ifPresent(
+        memberInfoDTO -> stompChatService.sendMessage(chatRoomId, messageDTO, memberInfoDTO));
   }
-
 
   @RabbitListener(queues = CHAT_QUEUE_NAME)
   public void receive(ChatMessageSpecResponse chatMessageSpecResponse) {
     System.out.println("received : " + chatMessageSpecResponse.getMessage());
-  }
-
-  private void sendNotification(MessageDTO messageDTO, String token) {
-    fcmNotificationService.sendNotification(
-        FcmNotificationRequest.of(messageDTO.getType().name(), messageDTO.getMessage()),
-        token);
   }
 
 }

--- a/src/main/java/com/windmealchat/chat/domain/MessageType.java
+++ b/src/main/java/com/windmealchat/chat/domain/MessageType.java
@@ -2,5 +2,5 @@ package com.windmealchat.chat.domain;
 
 public enum MessageType {
 
-    MESSAGE, IMAGE, EMOJI, SYSTEM, ERROR
+    TEXT, IMAGE, EMOJI, SYSTEM, ERROR
 }

--- a/src/main/java/com/windmealchat/chat/service/RabbitService.java
+++ b/src/main/java/com/windmealchat/chat/service/RabbitService.java
@@ -20,10 +20,9 @@ public class RabbitService {
   private final RabbitTemplate rabbitTemplate;
   private final AmqpAdmin admin;
 
-  public void createQueue(String chatroomId, ChatInitialRequest request) {
+  public void createQueue(String chatroomId, String oppositeEmail) {
     String queueName =
-        "room." + chatroomId + "." + request.getOppositeEmail()
-            .split("@")[0];
+        "room." + chatroomId + "." + oppositeEmail.split("@")[0];
     Queue queue = new Queue(queueName, true, false, false, null);
     admin.declareQueue(queue);
   }

--- a/src/main/java/com/windmealchat/chat/service/StompChatService.java
+++ b/src/main/java/com/windmealchat/chat/service/StompChatService.java
@@ -1,12 +1,7 @@
 package com.windmealchat.chat.service;
 
-import static com.windmealchat.global.constants.StompConstants.SYSTEM_GREETING;
-import static com.windmealchat.global.constants.TokenConstants.AUTHORIZATION_HEADER;
-
 import com.windmealchat.chat.domain.ChatroomDocument;
 import com.windmealchat.chat.domain.MessageDocument;
-import com.windmealchat.chat.domain.MessageType;
-import com.windmealchat.chat.dto.request.ChatInitialRequest;
 import com.windmealchat.chat.dto.request.MessageDTO;
 import com.windmealchat.chat.dto.response.ChatMessageResponse.ChatMessageSpecResponse;
 import com.windmealchat.chat.exception.ChatroomNotFoundException;
@@ -29,27 +24,6 @@ public class StompChatService {
   private final MessageDocumentRepository messageDocumentRepository;
   private final RabbitService rabbitService;
 
-  public void enter(String chatroomId, ChatInitialRequest chatInitialRequest, MemberInfoDTO memberInfoDTO) {
-    MessageDTO messageDTO = MessageDTO.builder()
-        .chatRoomId(chatroomId)
-        .type(MessageType.SYSTEM)
-        .build();
-    MessageDocument systemMessageDocument = messageDTO.toDocument(SYSTEM_GREETING);
-    ChatMessageSpecResponse systemMessageSpecResponse = ChatMessageSpecResponse.of(
-        systemMessageDocument);
-    ChatroomDocument chatroomDocument = chatroomDocumentRepository.findById(chatroomId)
-        .orElseThrow(() -> new ChatroomNotFoundException(ErrorCode.NOT_FOUND));
-    if (chatroomDocument.isDeletedByGuest() || chatroomDocument.isDeletedByOwner()) {
-      throw new ExitedChatroomException(ErrorCode.BAD_REQUEST);
-    }
-
-    messageDocumentRepository.save(systemMessageDocument);
-    rabbitService.createQueue(chatroomId, chatInitialRequest);
-    // 메시지를 각각 전송한다.
-    rabbitService.sendMessage(chatroomId, memberInfoDTO.getEmail(), systemMessageSpecResponse);
-    rabbitService.sendMessage(chatroomId, chatInitialRequest.getOppositeEmail(), systemMessageSpecResponse);
-  }
-
   public void sendMessage(String chatroomId, MessageDTO messageDTO, MemberInfoDTO memberInfoDTO) {
 
     MessageDocument messageDocument = messageDTO.toDocument(memberInfoDTO);
@@ -59,6 +33,7 @@ public class StompChatService {
     checkChatroom(chatroomId, memberInfoDTO);
     messageDocumentRepository.save(messageDocument);
     // 메시지를 각각 전송한다.
+    rabbitService.createQueue(chatroomId, messageDTO.getOppositeEmail());
     rabbitService.sendMessage(chatroomId, memberInfoDTO.getEmail(), chatMessageSpecResponse);
     rabbitService.sendMessage(chatroomId, messageDTO.getOppositeEmail(), chatMessageSpecResponse);
   }

--- a/src/main/java/com/windmealchat/global/configuration/WebSocketConfig.java
+++ b/src/main/java/com/windmealchat/global/configuration/WebSocketConfig.java
@@ -6,6 +6,8 @@ import static com.windmealchat.global.constants.StompConstants.PUB_PREFIX;
 import static com.windmealchat.global.constants.StompConstants.QUEUE;
 import static com.windmealchat.global.constants.StompConstants.TOPIC;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.windmealchat.alarm.service.FcmNotificationService;
 import com.windmealchat.global.handler.ClientInboundChannelHandler;
 import com.windmealchat.global.handler.HttpHandShakeInterceptor;
 import com.windmealchat.global.handler.StompErrorHandler;
@@ -47,8 +49,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   private String ws_host;
 
   private final AES256Util aes256Util;
+  private final ObjectMapper objectMapper;
   private final RedisTemplate redisTemplate;
   private final TokenProvider tokenProvider;
+  private final FcmNotificationService fcmNotificationService;
 
   @Bean
   public RefreshTokenDAO refreshTokenDAO() {
@@ -57,7 +61,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Bean
   public ChannelInterceptor channelInterceptor() {
-    return new ClientInboundChannelHandler(compositeMessageConverter(), tokenProvider, aes256Util);
+    return new ClientInboundChannelHandler(fcmNotificationService, tokenProvider, objectMapper, aes256Util);
   }
 
   @Bean
@@ -68,15 +72,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   @Bean
   public HandshakeInterceptor HttpHandShakeInterceptor() {
     return new HttpHandShakeInterceptor(aes256Util, tokenProvider, refreshTokenDAO());
-  }
-
-  @Bean
-  public MessageConverter compositeMessageConverter() {
-    // 일단 MappingJackson2MessageConverter만 포함하겠다.
-    List<MessageConverter> converters = List.of(
-        new MappingJackson2MessageConverter()
-    );
-    return new CompositeMessageConverter(converters);
   }
 
   @Override

--- a/src/main/java/com/windmealchat/global/handler/ClientInboundChannelHandler.java
+++ b/src/main/java/com/windmealchat/global/handler/ClientInboundChannelHandler.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.windmealchat.alarm.dto.FcmNotificationRequest;
 import com.windmealchat.alarm.service.FcmNotificationService;
 import com.windmealchat.chat.dto.request.MessageDTO;
-import com.windmealchat.global.auth.SimpleUserPrincipal;
 import com.windmealchat.global.token.impl.TokenProvider;
 import com.windmealchat.global.util.AES256Util;
 import com.windmealchat.member.dto.response.MemberInfoDTO;
@@ -37,13 +36,6 @@ public class ClientInboundChannelHandler implements ChannelInterceptor {
   private final ObjectMapper objectMapper;
   private final AES256Util aes256Util;
 
-  /*
-   * 웹소켓 연결을 맺은 클라이언트가 메세지를 보내기 전에, 권한이 있는지 체크하는 과정이다.
-   * 아래 코드를 보면 accessor.getSessionAttributes(); 부분이 나오는데, 이 부분은 Map 형식의 세션으로부터 토큰을 얻어오는 부분이다.
-   * 그리고 이 토큰은 HttpHandshakeInterceptor에서 핸드쉐이크 과정 중간에 가져온 쿠키의 토큰값이다.
-   * 공식문서에 따르면, 해당 메서드가 null을 반환할 시 실제 메세지 전송은 일어나지 않는다고 한다.
-   * 따라서 인증 정보가 유효하지 않다면 null을 반환하도록 하자.
-   */
   @Override
   public Message<?> preSend(Message<?> message, MessageChannel channel) {
     boolean isValid;
@@ -56,7 +48,8 @@ public class ClientInboundChannelHandler implements ChannelInterceptor {
   }
 
   /**
-   * 메시지 전송이 성공한 경우에만 알람을 발생시킨다.
+   * SEND 타입의 메시지가 전송 성공했을 경우에만 알람을 발생시킨다.
+   *
    * @param message
    * @param channel
    * @param sent
@@ -64,16 +57,18 @@ public class ClientInboundChannelHandler implements ChannelInterceptor {
   @Override
   public void postSend(Message<?> message, MessageChannel channel, boolean sent) {
 
-    if(!sent)
+    if (!sent) {
       return;
+    }
 
     StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
-    if(StompCommand.SEND.equals(accessor.getCommand())) {
+    if (StompCommand.SEND.equals(accessor.getCommand())) {
       Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
       String alarmToken = (String) sessionAttributes.get(ALARM_TOKEN);
-      String serializedMessageDTO = new String((byte[]) message.getPayload(), StandardCharsets.UTF_8);
+      String serializedMessageDTO = new String((byte[]) message.getPayload(),
+          StandardCharsets.UTF_8);
 
-      try{
+      try {
         MessageDTO messageDTO = objectMapper.readValue(serializedMessageDTO, MessageDTO.class);
         log.info(messageDTO.getMessage());
         sendNotification(messageDTO, alarmToken);
@@ -86,29 +81,29 @@ public class ClientInboundChannelHandler implements ChannelInterceptor {
   private boolean stompFilter(Message<?> message) throws JsonProcessingException {
     StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message,
         StompHeaderAccessor.class);
-    if (StompCommand.CONNECT.equals(accessor.getCommand()) || StompCommand.SUBSCRIBE.equals(
+
+    // CONNECT나 SUBSCRIBE가 아니라면 별도의 토큰 검사는 진행하지 않는다.
+    if (!StompCommand.CONNECT.equals(accessor.getCommand()) && !StompCommand.SUBSCRIBE.equals(
         accessor.getCommand())) {
-      Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
-      String accessToken = (String) sessionAttributes.get(TOKEN);
-      String authorizationHeader = accessor.getNativeHeader(AUTHORIZATION_HEADER).get(0);
-      String decrypt = aes256Util.decrypt(authorizationHeader)
-          .orElseThrow(() -> new MessageDeliveryException("인증 헤더가 존재하지 않습니다."));
-      if (!decrypt.equals(accessToken)) {
-        throw new MessageDeliveryException("인증 헤더와 토큰이 일치하지 않습니다.");
-      }
-      Optional<MemberInfoDTO> memberInfoFromToken = tokenProvider.getMemberInfoFromToken(
-          accessToken);
-      if (memberInfoFromToken.isPresent()) {
-        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
-          MemberInfoDTO memberInfoDTO = memberInfoFromToken.get();
-          accessor.setUser(new SimpleUserPrincipal(memberInfoDTO.getId(),
-              memberInfoDTO.getEmail(), memberInfoDTO.getNickname()));
-        }
-        return true;
-      }
+      return true;
+    }
+
+    Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+    String accessToken = (String) sessionAttributes.get(TOKEN);
+    String authorizationHeader = accessor.getNativeHeader(AUTHORIZATION_HEADER).get(0);
+    String decrypt = aes256Util.decrypt(authorizationHeader)
+        .orElseThrow(() -> new MessageDeliveryException("인증 헤더가 존재하지 않습니다."));
+    if (!decrypt.equals(accessToken)) {
+      throw new MessageDeliveryException("인증 헤더와 토큰이 일치하지 않습니다.");
+    }
+    Optional<MemberInfoDTO> memberInfoFromToken = tokenProvider.getMemberInfoFromToken(
+        accessToken);
+
+    if (memberInfoFromToken.isEmpty()) {
       return false;
     }
     return true;
+
   }
 
   private void sendNotification(MessageDTO messageDTO, String token) {


### PR DESCRIPTION
### PR 타입

- [x] 기능 수정

## 작업사항
- 알람 기능 분리 (ce69480530ab0632754870d593b3ac1dae4f2042)
     - 기존 controller에서 실행되던 알람 로직이, 트랜잭션을 고려하기 위해 메시지 전송 관련 콜백 메서드로 실행 위치가 변경됨
     - 이에 따른 기존 메서드의 불필요 로직 삭제 및 리팩토링 (3a64ea348262d8070cfbcb252f705d061d0dfcd4)
- ChannelInterceptor의 구현체 메서드에 즐비했던 ArrowHead pattern 리팩토링
