### PR TITLE
채팅방 정렬

### DIFF
--- a/src/main/java/com/windmealchat/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/windmealchat/chat/dto/response/ChatMessageResponse.java
@@ -2,6 +2,7 @@ package com.windmealchat.chat.dto.response;
 
 import com.windmealchat.chat.domain.MessageDocument;
 import com.windmealchat.chat.domain.MessageType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,7 +14,7 @@ import org.springframework.data.domain.Slice;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-//@Schema(title = "채팅 메시지")
+@Schema(title = "채팅 메시지")
 public class ChatMessageResponse {
 
   private Slice<ChatMessageSpecResponse> chatMessageSpecResponses;
@@ -30,13 +31,13 @@ public class ChatMessageResponse {
   @NoArgsConstructor
   @AllArgsConstructor
   public static class ChatMessageSpecResponse {
-//    @Schema(description = "채팅 메시지", example = "예정보다 조금 일찍 도착할 것 같습니다!")
+    @Schema(description = "채팅 메시지", example = "예정보다 조금 일찍 도착할 것 같습니다!")
     private String message;
-//    @Schema(description = "메시지 유형", example = "MESSAGE")
+    @Schema(description = "메시지 유형", example = "MESSAGE")
     private MessageType messageType;
-//    @Schema(description = "메시지 전송자 ID", example = "3")
+    @Schema(description = "메시지 전송자 ID", example = "3")
     private Long senderId;
-//    @Schema(description = "메시지 전송일", example = "2023-12-10T14:23:05.023")
+    @Schema(description = "메시지 전송일", example = "2023-12-10T14:23:05.023")
     private LocalDateTime createdTime;
 
     public static ChatMessageSpecResponse of(MessageDocument messageDocument) {

--- a/src/main/java/com/windmealchat/chat/dto/response/ChatroomResponse.java
+++ b/src/main/java/com/windmealchat/chat/dto/response/ChatroomResponse.java
@@ -21,21 +21,21 @@ public class ChatroomResponse {
   }
 
   @Getter
-  public static class ChatroomSpecResponse {
+  public static class ChatroomSpecResponse implements Comparable<ChatroomSpecResponse>{
 
     private String chatroomId;
     private String lastMessage;
     private MessageType messageType;
-    private LocalDateTime createdDate;
+    private LocalDateTime lastMessageTime;
     private int uncheckedMessageCount;
     private String oppositeAlarmToken;
 
     private ChatroomSpecResponse(String chatroomId, String lastMessage, MessageType messageType,
-        LocalDateTime createdDate, int uncheckedMessageCount, String oppositeAlarmToken) {
+        LocalDateTime lastMessageTime, int uncheckedMessageCount, String oppositeAlarmToken) {
       this.chatroomId = chatroomId;
       this.lastMessage = lastMessage;
       this.messageType = messageType;
-      this.createdDate = createdDate;
+      this.lastMessageTime = lastMessageTime;
       this.oppositeAlarmToken = oppositeAlarmToken;
       this.uncheckedMessageCount = uncheckedMessageCount;
     }
@@ -44,13 +44,17 @@ public class ChatroomResponse {
         MessageDocument messageDocument, int uncheckedMessageCount, String oppositeAlarmToken) {
       String lastMessage = messageDocument != null ? messageDocument.getMessage() : "";
       // 마지막으로 전송된 메시지가 없어서 전송 시간을 표시할 수 없는 경우는 채팅방이 생성된 시간을 대신 반환한다.
-      // 디펜시브다. 채팅방 입장과 동시에 시스템 메시지가 전송되기 때문에 메시지가 비어있을 일은 없다.
       LocalDateTime createdTime = messageDocument != null ? messageDocument.getCreatedTime()
           : chatroomDocument.getCreatedTime();
       MessageType lastMessageType =
           messageDocument != null ? messageDocument.getMessageType() : MessageType.SYSTEM;
       return new ChatroomSpecResponse(chatroomDocument.getId(), lastMessage, lastMessageType,
           createdTime, uncheckedMessageCount, oppositeAlarmToken);
+    }
+
+    @Override
+    public int compareTo(ChatroomSpecResponse o) {
+      return o.lastMessageTime.compareTo(this.lastMessageTime);
     }
   }
 }

--- a/src/main/java/com/windmealchat/chat/repository/ChatroomDocumentRepository.java
+++ b/src/main/java/com/windmealchat/chat/repository/ChatroomDocumentRepository.java
@@ -1,6 +1,7 @@
 package com.windmealchat.chat.repository;
 
 import com.windmealchat.chat.domain.ChatroomDocument;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -12,6 +13,9 @@ public interface ChatroomDocumentRepository extends MongoRepository<ChatroomDocu
 
   @Query("{ $or: [ { 'guestId': ?0, 'isDeletedByGuest': false }, { 'ownerId': ?1, 'isDeletedByOwner': false } ] }")
   Slice<ChatroomDocument> findActiveChatrooms(Long guestId, Long ownerId, Pageable pageable);
+
+  @Query("{ $or: [ { 'guestId': ?0, 'isDeletedByGuest': false }, { 'ownerId': ?1, 'isDeletedByOwner': false } ] }")
+  List<ChatroomDocument> findAllActiveChatrooms(Long guestId, Long ownerId);
 
 
 

--- a/src/main/java/com/windmealchat/global/handler/HttpHandShakeInterceptor.java
+++ b/src/main/java/com/windmealchat/global/handler/HttpHandShakeInterceptor.java
@@ -7,27 +7,19 @@ import static com.windmealchat.global.constants.TokenConstants.PREFIX_REFRESHTOK
 import static com.windmealchat.global.constants.TokenConstants.TOKEN;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.windmealchat.chat.exception.AuthorizationException;
-import com.windmealchat.global.exception.ErrorCode;
-import com.windmealchat.global.exception.ExceptionResponseDTO;
 import com.windmealchat.global.token.dao.RefreshTokenDAO;
 import com.windmealchat.global.token.impl.TokenProvider;
 import com.windmealchat.global.util.AES256Util;
 import com.windmealchat.member.dto.response.MemberInfoDTO;
-import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
-import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.web.socket.WebSocketHandler;
-import org.springframework.web.socket.server.HandshakeFailureException;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
 @Slf4j

--- a/src/main/java/com/windmealchat/global/handler/StompErrorHandler.java
+++ b/src/main/java/com/windmealchat/global/handler/StompErrorHandler.java
@@ -31,14 +31,11 @@ public class StompErrorHandler extends StompSubProtocolErrorHandler {
     accessor.setLeaveMutable(true);
     StompHeaderAccessor clientHeaderAccessor = null;
     if (clientMessage != null) {
-      log.info("1 :" + new String((byte[]) clientMessage.getPayload()));
       clientHeaderAccessor = MessageHeaderAccessor.getAccessor(clientMessage,
           StompHeaderAccessor.class);
       if (clientHeaderAccessor != null) {
-        log.info("2");
         String receiptId = clientHeaderAccessor.getReceipt();
         if (receiptId != null) {
-          log.info("3");
           accessor.setReceiptId(receiptId);
         }
       }


### PR DESCRIPTION
### PR 타입

- [x] 기능 추가

## 작업사항
- 채팅방 최근 메시지 순으로 정렬 (8d17534bb39d4de1ad0b1f9484fb726d148ea156)
     - 해당 기능 구현을 위해서 많이 고민했는데, 결과적으로 다음과 같이 구현되었음 ::
          - 특정 사용자가 속한 (나가지 않은) 채팅방 전체를 조회한 후 마지막 메시지, 읽지 않은 메시지 등을 모두 합쳐 DTO 생성
          - 생성된 DTO 리스트를 대상으로 정렬 수행
          - 정렬된 리스트에 대해서 페이지네이션 요청에 따라 일부 건수만 반환

해당 방식에서 연산의 낭비가 있음을 인지하고 있음. 
하지만 페이지네이션 적용과 정렬을 동시에 진행해야 했고, 기존 방식은 채팅방을 먼저 페이지네이션 적용하여 조회 후 해당 채팅방에 맞는 메시지를 나중에 붙여주는 방식이었음. 그래서 채팅방을 조회하는 시점에는 어떤 채팅방을 우선으로 조회해야할지 알 수 없었고, 이것을 해결하기 위해 
+ 채팅방별로 마지막 메시지 필드를 추가하여 매 채팅마다 해당 필드를 지속적으로 업데이트 해주거나(1), 
+ 아니면 전체 채팅 메시지 컬렉션을 대상으로 쿼리하여 채팅방 아이디를 기준으로 group by후 사용자 아이디로 필터링해야 했는데(2) 

이 모든 방법 중 현재의 방법 (채팅방 전체 조회 후 마지막 메시지를 얻어오고 이를 기준으로 정렬 후 페이지 요청에 해당되는 부분만 반환)이 가장 적절하다 판단했음.
#### 혹시 더 괜찮은 구현방법이나 아이디어가 있으면 언제든지 제안 바람.