### PR TITLE
웹소켓 커넥션 파라미터 변경, 알람토큰 위치 수정

### DIFF
--- a/src/main/java/com/windmealchat/chat/controller/ChatRestController.java
+++ b/src/main/java/com/windmealchat/chat/controller/ChatRestController.java
@@ -23,12 +23,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -40,7 +35,7 @@ public class ChatRestController {
   private final ChatroomService chatroomService;
   private final TokenService tokenService;
 
-  @GetMapping("/{chatroomId}")
+  @GetMapping
   @Operation(summary = "채팅방의 메시지 리스트 조회 요청", description = "특정 채팅방의 메시지 리스트를 조회합니다.")
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = "메시지 리스트 조회 성공"),
@@ -53,7 +48,7 @@ public class ChatRestController {
       @ApiResponse(responseCode = "404", description = "채팅방을 찾을 수 없습니다.",
           content = @Content(schema = @Schema(implementation = ExceptionResponseDTO.class))),
   })
-  public ResultDataResponseDTO<ChatMessageResponse> messageList(@PathVariable String chatroomId,
+  public ResultDataResponseDTO<ChatMessageResponse> messageList(@RequestParam String chatroomId,
       Pageable pageable, HttpServletRequest request) {
     MemberInfoDTO memberInfoDTO = tokenService.resolveJwtTokenFromHeader(resolveToken(request));
     ChatMessageResponse chatMessages = chatroomService.getChatMessages(memberInfoDTO, pageable,

--- a/src/main/java/com/windmealchat/chat/dto/request/MessageDTO.java
+++ b/src/main/java/com/windmealchat/chat/dto/request/MessageDTO.java
@@ -19,6 +19,7 @@ public class MessageDTO {
     private String chatRoomId;
     private MessageType type;
     private String message;
+    private String opponentAlarmToken;
 
     public MessageDocument toDocument(String decryptedId, MemberInfoDTO memberInfoDTO) {
         return new MessageDocument(decryptedId,this, memberInfoDTO);

--- a/src/main/java/com/windmealchat/global/handler/ClientInboundChannelHandler.java
+++ b/src/main/java/com/windmealchat/global/handler/ClientInboundChannelHandler.java
@@ -81,7 +81,7 @@ public class ClientInboundChannelHandler implements ChannelInterceptor {
     StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
     if (StompCommand.SEND.equals(accessor.getCommand())) {
       Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
-      String alarmToken = (String) sessionAttributes.get(ALARM_TOKEN);
+//      String alarmToken = (String) sessionAttributes.get(ALARM_TOKEN);
       String accessToken = (String) sessionAttributes.get(TOKEN);
       String serializedMessageDTO = new String((byte[]) message.getPayload(),
           StandardCharsets.UTF_8);
@@ -90,7 +90,7 @@ public class ClientInboundChannelHandler implements ChannelInterceptor {
         MessageDTO messageDTO = objectMapper.readValue(serializedMessageDTO, MessageDTO.class);
         MemberInfoDTO memberInfoFromToken = tokenProvider.getMemberInfoFromToken(
             accessToken).get();
-        sendNotification(messageDTO, alarmToken, memberInfoFromToken.getNickname());
+        sendNotification(messageDTO, messageDTO.getOpponentAlarmToken(), memberInfoFromToken.getNickname());
       } catch (JsonProcessingException e) {
         throw new MessageDeliveryException(DESERIALIZATION_EXCEPTION);
       } catch (NoSuchElementException e) {

--- a/src/main/java/com/windmealchat/global/handler/HttpHandShakeInterceptor.java
+++ b/src/main/java/com/windmealchat/global/handler/HttpHandShakeInterceptor.java
@@ -36,7 +36,7 @@ public class HttpHandShakeInterceptor implements HandshakeInterceptor {
       ServletServerHttpRequest servletServerHttpRequest = (ServletServerHttpRequest) request;
       HttpServletRequest servletRequest = servletServerHttpRequest.getServletRequest();
         String token = resolveToken(servletRequest, CODE);
-      String alarmToken = resolveToken(servletRequest, CODE_A);
+//      String alarmToken = resolveToken(servletRequest, CODE_A);
       Optional<MemberInfoDTO> memberInfoDTO = resolveMemberInfo(token);
       if (memberInfoDTO.isPresent()) {
         String key =
@@ -44,7 +44,7 @@ public class HttpHandShakeInterceptor implements HandshakeInterceptor {
         Optional<String> refreshToken = refreshTokenDAO.getRefreshToken(aes256Util.encrypt(key));
         if (refreshToken.isPresent()) {
           attributes.put(TOKEN, token);
-          attributes.put(ALARM_TOKEN, alarmToken);
+//          attributes.put(ALARM_TOKEN, alarmToken);
           return true;
         }
       }


### PR DESCRIPTION
### PR 타입

- [x] 기능 수정

## 작업사항
- 웹소켓 커넥션 파라미터 변경
     - 기존에는 커넥션 시점에 알람토큰을 전달받았지만, 커넥션 시점이 달라짐으로써 토큰을 전달받을 수 없게 됨
     - 따라서 채팅 메시지에 상대방의 알람토큰을 실어서 전달하는 구조로 변경
- 알람토큰 위치 수정
     - 위 수정사항에 따라 알람토큰의 위치는 채팅 메시지 DTO로 변경
    
- 기존의 암호화로 인한 오류 수정
     - PathVariable로 전달되는 채팅방 ID가 암호화 과정에서 "/"를 포함하게 되었고, 이로 인해 URI 인식 오류가 발생함.
     - RequestParam으로 변경하여 해결 
